### PR TITLE
fix When the delete pop-up box that pops up after double-clicking a d…

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -206,7 +206,7 @@
     <string name="desktop_new_directory">"新建文件夹"</string>
     <string name="desktop_new_paste">"粘贴"</string>
     <string name="desktop_tips">"提示"</string>
-    <string name="app_not_install">"应用未安装,是否删除该图标"</string>
+    <string name="app_not_install">"应用未安装,是否删除图标？"</string>
     <string name="desktop_delete_tips">"是否删除？"</string>
     <string name="desktop_delete">"删除"</string>
     <string name="desktop_cancel">"取消"</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -496,7 +496,7 @@
     <string name="desktop_new_directory">"New directory"</string>
     <string name="desktop_new_paste">"paste"</string>
     <string name="desktop_tips">"Tips"</string>
-    <string name="app_not_install">"The application is not installed. Do you want to delete this icon? "</string>
+    <string name="app_not_install">"App not installed. Remove this icon? "</string>
     <string name="desktop_delete_tips">"is delete?"</string>
     <string name="desktop_delete">"delete"</string>
     <string name="desktop_cancel">"cancel"</string>


### PR DESCRIPTION
…isabled desktop application icon contains too many characters, it cannot be fully displayed. It is recommended to stretch and enlarge the window based on the number of characters